### PR TITLE
check ideastatus in results for existing value

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -509,7 +509,11 @@ function getJoinedGameOnExpand(element,error_object,progress_element=null){
                         } else if (json_data.status == 'ok'){
                             error_object.removeClass('error-text');
                             clearMaterialInputBox(ideaBox);
-                            error_object.text("Successful Submission.");
+                            if (json_data.ideastatus == "Existing"){
+                                error_object.text("You already submitted this idea, try another one.");
+                            } else {
+                                error_object.text("Successful Submission.");
+                            }
                         }
                         hide_progress(progress_object);
                         enable_button(button_object);


### PR DESCRIPTION
Gives user feedback for idea duplicates from Backend's pr #9.

Duplicates are not an error state so we just change the success message.